### PR TITLE
Support logstash ttl and bulk_max_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+##2019-06-27 - Release 1.0.1
+###Summary
+
+Add support for the following config options to logstash output
+* ttl
+* bulk_max_size
+
 ##2019-04-25 - Release 1.0.0
 ###Summary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-##2019-06-27 - Release 1.0.1
+##2019-06-28 - Release 1.0.3
+###Summary
+
+NFR: Fix README format
+
+##2019-06-27 - Release 1.0.2
 ###Summary
 
 Add support for the following config options to logstash output

--- a/README.md
+++ b/README.md
@@ -35,71 +35,83 @@ Use puppet module install function to install module and simply include it from 
 
 The module can be called with the following parameters:
 
-*`prospectors` OPTIONAL
+#`prospectors` OPTIONAL
 
 An array of Hashes that specifies which groups of prospectors log entries the filebeats application must export.
 This value should be used if you wish to have more than one prospector.
 
-*`logstash_hosts`
+#`logstash_hosts`
 
 An array of strings that specifies remote hosts to use for logstash outputs, e.g ['localhost:5044']
 If left empty then all other logstash options are ignored
 
-*`logstash_index`
+#`logstash_bulk_max_size`
+
+A Number representing the maximum number of events to bulk in a single Logstash request, e.g 2048
+Setting this to zero or negative disables the splitting of batches.
+
+#`logstash_index`
 
 A string that specifies the index to use for the logstash output, defaults to '[filebeat-]YYYY.MM.DD' as per the package.
 
-*`logstash_ssl_certificate_authorities`
+#`logstash_ssl_certificate_authorities`
 
 An array of Strings that specifies paths to Certificate authority files when connecting to logstash.
 
-*`logstash_ssl_certificate`
+#`logstash_ssl_certificate`
 
 A String that specifies a path to your hosts certificate to use when connecting to logstash.
 
-*`logstash_ssl_certificate_key`
+#`logstash_ssl_certificate_key`
 
 A String that specifies a path to your hosts certificate key to use when connecting to logstash.
 
-*`logstash_worker`
+#`logstash_ttl`
+
+A String that specifies the Time To Live for a connection to Logstash, you must use a elastic duration e.g. '5m', '1h', '45s'
+ see https://www.elastic.co/guide/en/beats/libbeat/master/config-file-format-type.html#_duration
+ NOTE: this option explicitly disables pipelining, it is not compatible with the async logstash client
+ https://www.elastic.co/guide/en/beats/filebeat/current/logstash-output.html#_literal_ttl_literal
+
+#`logstash_worker`
 
 A integer that specifies the number of workers participating in the load balancing
 
-*`logstash_loadbalance`
+#`logstash_loadbalance`
 
 A boolean to turn on or off load balancing for logstash outputs, defaults to false.
 
-*`elasticsearch_hosts`
+#`elasticsearch_hosts`
 
 A array containing the hostname/s of your elasticsearch host/s used for send the transactions directly
 to Elasticsearch by using the Elasticsearch HTTP API.
 If left empty then all other elasticsearch options are ignored
 
-*`elasticsearch_username`
+#`elasticsearch_username`
 
 The username filebeats should use to authenticate should your cluster make use of shield
 
-*`elasticsearch_password`
+#`elasticsearch_password`
 
 The password filebeats should use to authenticate should your cluster make use of shield
 
-*`elasticsearch_protocol`
+#`elasticsearch_protocol`
 
 A string containing the protocol used by filebeats, defaults to http. 
 
-*`elasticsearch_index`
+#`elasticsearch_index`
 
 A string that specifies the index to use for the elasticsearch output, defaults to '[filebeat-]YYYY.MM.DD' as per the package.
 
-*`elasticsearch_ssl_certificate_authorities`
+#`elasticsearch_ssl_certificate_authorities`
 
 An array of Strings that specifies paths to Certificate authority files.
 
-*`elasticsearch_ssl_certificate`
+#`elasticsearch_ssl_certificate`
 
 A String that specifies a path to your hosts certificate to use when connecting to elasticsearch.
 
-*`elasticsearch_ssl_certificate_key`
+#`elasticsearch_ssl_certificate_key`
 
 A String that specifies a path to your hosts certificate key to use when connecting to elasticsearch.
 
@@ -119,19 +131,19 @@ A boolean that allows you to overwrite the existing template.
 
 A string that specifies the path to the template file
 
-*`export_log_paths`
+#`export_log_paths`
 
 An array of Strings that specifies which logs the filebeats application must export.
 
-*`log_settings`
+#`log_settings`
 
 A puppet Hash containing log level ('debug', 'warning', 'error' or 'critical'), to_syslog(true/false), path('/var/log/filebeat'), keepfiles(7), rotateeverybytes(10485760), name(filebeats.log)
 
-*`service_bootstrapped`
+#`service_bootstrapped`
 
 A boolean to turn on or off the filebeat service at boot ('false'/'true'), defaults to 'true'
 
-*`service_state`
+#`service_state`
 
 A string to describe the state of the filebeats service ('stopped'/'running'), defaults to 'running'
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,12 +21,14 @@ class filebeats::config (
   Array   $export_log_paths,
   Hash    $log_settings,
   Array   $logstash_hosts,
+  Integer $logstash_bulk_max_size,
   String  $logstash_index,
   Boolean $logstash_loadbalance,
   Integer $logstash_worker,
   String  $logstash_ssl_certificate,
   Array   $logstash_ssl_certificate_authorities,
   String  $logstash_ssl_certificate_key,
+  String  $logstash_ttl,
   Array   $prospectors,
 ){
   $config_path = $filebeats::params::config_path
@@ -35,6 +37,12 @@ class filebeats::config (
     $logging = {}
   } else {
     $logging = merge($::filebeats::params::log_settings, $log_settings)
+  }
+
+  if !empty($logstash_ttl) {
+    if $logstash_ttl !~ /^\-?[0-9]+\.?[0-9]*(?:ns|us|ms|s|m|h)$/ {
+      fail("Parameter \$logstash_ttl with content '${logstash_ttl}': is not a valid elastic duration")
+    }
   }
 
   if empty($prospectors) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,14 @@
 # An array of strings that specifies remote hosts to use for logstash outputs, e.g ['localhost:5044']
 # *`logstash_index`
 # A string that specifies the index to use for the logstash output, defaults to '[filebeat-]YYYY.MM.DD' as per the package.
+# *`logstash_bulk_max_size`
+# A number representing the maximum number of events to bulk in a single Logstash request, e.g 2048
+#   Setting this to zero or negative disables the splitting of batches.
+# *`logstash_ttl`
+# A string that specifies the Time To Live for a connection to Logstash, you must use a elastic duration e.g. '5m', '1h', '45s'
+#  see https://www.elastic.co/guide/en/beats/libbeat/master/config-file-format-type.html#_duration
+#  NOTE: this option explicitly disables pipelining, it is not cmpatibly with the async logstash client
+#  https://www.elastic.co/guide/en/beats/filebeat/current/logstash-output.html#_literal_ttl_literal
 # *`elasticsearch_index`
 # A string that specifies the index to use for the elasticsearch output, defaults to '[filebeat-]YYYY.MM.DD' as per the package.
 #
@@ -80,11 +88,13 @@ class filebeats (
   $export_log_paths                          = $filebeats::params::export_log_paths,
   $log_settings                              = {},
   $logstash_hosts                            = $filebeats::params::logstash_hosts,
+  $logstash_bulk_max_size                    = $filebeats::params::logstash_bulk_max_size,
   $logstash_index                            = $filebeats::params::logstash_index,
   $logstash_loadbalance                      = $filebeats::params::logstash_loadbalance,
   $logstash_ssl_certificate                  = $filebeats::params::logstash_ssl_certificate,
   $logstash_ssl_certificate_authorities      = $filebeats::params::logstash_ssl_certificate_authorities,
   $logstash_ssl_certificate_key              = $filebeats::params::logstash_ssl_certificate_key,
+  $logstash_ttl                              = $filebeats::params::logstash_ttl,
   $logstash_worker                           = $filebeats::params::logstash_worker,
   $prospectors                               = $filebeats::params::prospectors,
   $service_bootstrapped                      = $filebeats::params::service_bootstrapped,
@@ -115,11 +125,13 @@ class filebeats (
     export_log_paths                          => $export_log_paths,
     log_settings                              => $log_settings,
     logstash_hosts                            => $logstash_hosts,
+    logstash_bulk_max_size                    => $logstash_bulk_max_size,
     logstash_index                            => $logstash_index,
     logstash_loadbalance                      => $logstash_loadbalance,
     logstash_ssl_certificate                  => $logstash_ssl_certificate,
     logstash_ssl_certificate_authorities      => $logstash_ssl_certificate_authorities,
     logstash_ssl_certificate_key              => $logstash_ssl_certificate_key,
+    logstash_ttl                              => $logstash_ttl,
     logstash_worker                           => $logstash_worker,
     prospectors                               => $prospectors,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@
 # *`logstash_ttl`
 # A string that specifies the Time To Live for a connection to Logstash, you must use a elastic duration e.g. '5m', '1h', '45s'
 #  see https://www.elastic.co/guide/en/beats/libbeat/master/config-file-format-type.html#_duration
-#  NOTE: this option explicitly disables pipelining, it is not cmpatibly with the async logstash client
+#  NOTE: this option explicitly disables pipelining, it is not compatible with the async logstash client
 #  https://www.elastic.co/guide/en/beats/filebeat/current/logstash-output.html#_literal_ttl_literal
 # *`elasticsearch_index`
 # A string that specifies the index to use for the elasticsearch output, defaults to '[filebeat-]YYYY.MM.DD' as per the package.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,11 +15,13 @@ class filebeats::params {
   $elasticsearch_username                    = ''
   $logstash_hosts                            = []
   $logstash_index                            = ''
+  $logstash_bulk_max_size                    = 2048
   $logstash_loadbalance                      = false
   $logstash_worker                           = 1
   $logstash_ssl_certificate                  = ''
   $logstash_ssl_certificate_authorities      = []
   $logstash_ssl_certificate_key              = ''
+  $logstash_ttl                              = ''
   $prospectors                               = []
   $service_bootstrapped                      = true
   $service_state                             = 'running'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hetzner-filebeats",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "author": "Henlu Starke",
   "summary": "Simple module to install and configure filebeats for elasticsearch",
   "license": "Apache-2.0",
@@ -28,11 +28,11 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "4.x"
+      "version_requirement": ">= 4.0 < 6.0"
     },
     {
       "name": "filebeats",
-      "version_requirement": "5.6.x"
+      "version_requirement": ">= 5.6.x < 6.3.0"
     }
   ],
   "pdk-version": "1.10.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hetzner-filebeats",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Henlu Starke",
   "summary": "Simple module to install and configure filebeats for elasticsearch",
   "license": "Apache-2.0",

--- a/templates/filebeat.yml.erb
+++ b/templates/filebeat.yml.erb
@@ -50,9 +50,6 @@ output.logstash:
 <% if @logstash_worker > 1 -%>
   worker: <%= @logstash_worker %>
 <% end -%>
-<% if @logstash_bulk_max_size != 2048 -%>
-  bulk_max_size: <%= @logstash_bulk_max_size %>
-<% end -%>
 <% if @logstash_ttl != '' -%>
   ttl: <%= @logstash_ttl %>
   pipelining: 0
@@ -69,6 +66,7 @@ output.logstash:
 <% if @logstash_ssl_certificate_key != '' -%>
   ssl.key: <%= @logstash_ssl_certificate_key %>
 <% end -%>
+  bulk_max_size: <%= @logstash_bulk_max_size %>
 <% end -%>
 <% if @elasticsearch_hosts != [] -%>
 

--- a/templates/filebeat.yml.erb
+++ b/templates/filebeat.yml.erb
@@ -50,6 +50,13 @@ output.logstash:
 <% if @logstash_worker > 1 -%>
   worker: <%= @logstash_worker %>
 <% end -%>
+<% if @logstash_bulk_max_size != 2048 -%>
+  bulk_max_size: <%= @logstash_bulk_max_size %>
+<% end -%>
+<% if @logstash_ttl != '' -%>
+  ttl: <%= @logstash_ttl %>
+  pipelining: 0
+<% end -%>
 <% if @logstash_index != '' -%>
   index: <%= @logstash_index %>
 <% end -%>


### PR DESCRIPTION
TTL will disable pipelining, due to not being supported in async logstash client
Bulk max size always defaults to the default 2048