### PR TITLE
Apt update before package installation

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -7,6 +7,7 @@ class filebeats::package {
         ensure  => present,
         require => Class['::elastic_stack::repo']
       }
+      Class['apt::update'] -> Package['filebeat']
     }
     default: {
       fail('Could not configure apt resource for elasticsearch filebeats')


### PR DESCRIPTION
Hello

This commit fixes an ordering violation.
Specifically, executing `apt update` must precede package installation.

This is the error I get, when Puppet tries to install the package before invoking `apt-update`.

```
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install filebeat' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package filebeat
Error: /Stage[main]/Filebeats::Package/Package[filebeat]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install filebeat' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package filebeat
Notice: /Stage[main]/Filebeats::Config/File[/etc/filebeat/filebeat.yml]: Dependency Package[filebeat] has failures: true
Warning: /Stage[main]/Filebeats::Config/File[/etc/filebeat/filebeat.yml]: Skipping because of failed dependencies
Notice: /Stage[main]/Filebeats::Service/Service[filebeat]: Dependency Package[filebeat] has failures: true
Warning: /Stage[main]/Filebeats::Service/Service[filebeat]: Skipping because of failed dependencies
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 events
```

More details in the official documentation of puppetlabs-apt:
https://github.com/puppetlabs/puppetlabs-apt#adding-new-sources-or-ppas

 > If you are adding a new source and trying to install packagesfrom the new source on the same Puppet run, your package resourceshould depend on Class[’apt::update’], as well as depending on theApt::Source resource”
