### PR TITLE
Converting prospectors to inputs for v7.9 breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Use puppet module install function to install module and simply include it from 
 
 The module can be called with the following parameters:
 
-#`prospectors` OPTIONAL
+#`inputs` OPTIONAL
 
-An array of Hashes that specifies which groups of prospectors log entries the filebeats application must export.
-This value should be used if you wish to have more than one prospector.
+An array of Hashes that specifies which groups of inputs (formally known as prospectors) log entries the filebeats application must export.
+This value should be used if you wish to have more than one input.
 
 #`logstash_hosts`
 
@@ -160,11 +160,11 @@ Auth.log being exported with elasticsearch out requiring a user and password.
    }
 ```
 
-Multiple prospectors with multiple log files being exported to multiple logstash hosts.
+Multiple inputs with multiple log files being exported to multiple logstash hosts.
 
 ```
    class { 'filebeats':
-     prospectors          => [{ 'input_type'    => 'log',
+     inputs          => [{ 'input_type'    => 'log',
                                 'doc_type'      => 'log',
                                 'paths'         => ['/var/log/auth.log'],
                                 'include_lines' => "['sshd','passwd','vigr']",
@@ -184,7 +184,7 @@ Multiple prospectors with multiple log files being exported to multiple logstash
 ## Hiera data example
 
 ```
-filebeats::prospectors:
+filebeats::inputs:
   - input_type: 'log'
     paths:
       - '/var/log/auth.log'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,7 +29,7 @@ class filebeats::config (
   Array   $logstash_ssl_certificate_authorities,
   String  $logstash_ssl_certificate_key,
   String  $logstash_ttl,
-  Array   $prospectors,
+  Array   $inputs,
 ){
   $config_path = $filebeats::params::config_path
 
@@ -45,15 +45,15 @@ class filebeats::config (
     }
   }
 
-  if empty($prospectors) {
+  if empty($inputs) {
     validate_array($export_log_paths)
 
-    $prospectors_array =  [{'paths'         => $export_log_paths,
+    $inputs_array =  [{'paths'         => $export_log_paths,
                             'input_type'    => 'log',
                             'doc_type' => 'log'
                           }]
   } else {
-    $prospectors_array = $prospectors
+    $inputs_array = $inputs
   }
 
   file {"${config_path}/filebeat.yml":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,8 +10,8 @@
 #
 # * `export_log_paths`
 # An array of Strings that specifies which logs the filebeats application must export.
-# * `prospectors`
-# An array of Hashes that specifies which groups of prospectors log entries the filebeats application must export.
+# * `inputs`
+# An array of Hashes that specifies which groups of inputs log entries the filebeats application must export.
 # * `elasticsearch_username`
 # The username filebeats should use to authenticate should your cluster make use of elasticsearch
 # * `elasticsearch_password`
@@ -96,7 +96,7 @@ class filebeats (
   $logstash_ssl_certificate_key              = $filebeats::params::logstash_ssl_certificate_key,
   $logstash_ttl                              = $filebeats::params::logstash_ttl,
   $logstash_worker                           = $filebeats::params::logstash_worker,
-  $prospectors                               = $filebeats::params::prospectors,
+  $inputs                                    = $filebeats::params::inputs,
   $service_bootstrapped                      = $filebeats::params::service_bootstrapped,
   $service_state                             = $filebeats::params::service_state,
 ) inherits ::filebeats::params {
@@ -133,7 +133,7 @@ class filebeats (
     logstash_ssl_certificate_key              => $logstash_ssl_certificate_key,
     logstash_ttl                              => $logstash_ttl,
     logstash_worker                           => $logstash_worker,
-    prospectors                               => $prospectors,
+    inputs                                    => $inputs,
   }
 
   Class['::filebeats::params']-> Class['::filebeats::config']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class filebeats::params {
   $logstash_ssl_certificate_authorities      = []
   $logstash_ssl_certificate_key              = ''
   $logstash_ttl                              = ''
-  $prospectors                               = []
+  $inputs                                    = []
   $service_bootstrapped                      = true
   $service_state                             = 'running'
   $log_settings                              =  {

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,8 @@
 {
   "name": "hetzner-filebeats",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Henlu Starke",
-  "summary": "Simple module to install and configure filebeats for elasticsearch",
+  "summary": "Simple module to install and configure filebeats for Elasticsearch",
   "license": "Apache-2.0",
   "source": "git@github.com:hetznerZA/hetzner-filebeats.git",
   "project_page": "https://github.com/hetznerZA/hetzner-filebeats",

--- a/templates/filebeat.yml.erb
+++ b/templates/filebeat.yml.erb
@@ -1,42 +1,42 @@
 filebeat:
-  prospectors:
-<% @prospectors_array.each do | prospector | -%>
-<% if prospector['input_type'] -%>
-    - type: <%= prospector['input_type'] %>
+  inputs:
+<% @inputs_array.each do | input | -%>
+<% if input['input_type'] -%>
+    - type: <%= input['input_type'] %>
 <% end -%>
       paths:
-<% prospector['paths'].each do |path| -%>
+<% input['paths'].each do |path| -%>
         - <%= path %>
 <% end -%>
-<% if prospector['doc_type'] != '' -%>
-      document_type: <%= prospector['doc_type'] %>
+<% if input['doc_type'] != '' -%>
+      document_type: <%= input['doc_type'] %>
 <% end -%>
-<% if prospector['tags'] -%>
-      tags: [<%= prospector['tags'].map{|tag| "#{tag}"}.join(',') %>]
+<% if input['tags'] -%>
+      tags: [<%= input['tags'].map{|tag| "#{tag}"}.join(',') %>]
 <% end -%>
-<% if prospector['include_lines'] -%>
-      include_lines: <%= prospector['include_lines'] %>
+<% if input['include_lines'] -%>
+      include_lines: <%= input['include_lines'] %>
 <% end -%>
-<% if prospector['exclude_lines'] -%>
-      exclude_lines: <%= prospector['exclude_lines'] %>
+<% if input['exclude_lines'] -%>
+      exclude_lines: <%= input['exclude_lines'] %>
 <% end -%>
-<% if prospector['fields'] -%>
+<% if input['fields'] -%>
       fields:
-  <% prospector['fields'].each do |k,v| -%>
+  <% input['fields'].each do |k,v| -%>
         <%= k %>: '<%= v %>'
   <% end -%>
 <% end -%>
-<% if prospector['json_keys_under_root'] -%>
-      json.keys_under_root: <%= prospector['json_keys_under_root'] %>
+<% if input['json_keys_under_root'] -%>
+      json.keys_under_root: <%= input['json_keys_under_root'] %>
 <% end -%>
-<% if prospector['json_overwrite_keys'] -%>
-      json.overwrite_keys: <%= prospector['json_overwrite_keys'] %>
+<% if input['json_overwrite_keys'] -%>
+      json.overwrite_keys: <%= input['json_overwrite_keys'] %>
 <% end -%>
-<% if prospector['json_add_error_key'] -%>
-      json.add_error_key: <%= prospector['json_add_error_key'] %>
+<% if input['json_add_error_key'] -%>
+      json.add_error_key: <%= input['json_add_error_key'] %>
 <% end -%>
-<% if prospector['json_message_key'] -%>
-      json.message_key: <%= prospector['json_message_key'] %>
+<% if input['json_message_key'] -%>
+      json.message_key: <%= input['json_message_key'] %>
 <% end -%>
 <% end -%>
   registry_file: /var/lib/filebeat/registry


### PR DESCRIPTION
Adding support to use `inputs` instead of `prospectors` in preparation for v7.x filebeat changes